### PR TITLE
Replace ASCII loaders with ThinkingSpinner (UI & mobile)

### DIFF
--- a/packages/mobile/src/components/PageLoader.tsx
+++ b/packages/mobile/src/components/PageLoader.tsx
@@ -1,20 +1,22 @@
 import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
-import { AsciiSpinner } from '@vuhlp/spinners/native';
+import { ThinkingSpinner } from '@vuhlp/spinners/native';
 import { colors, fontFamily, fontSize, spacing, radius } from '@/lib/theme';
 
 interface PageLoaderProps {
   error?: string | null;
   onRetry?: () => void;
-  size?: number;
+  size?: 'sm' | 'lg';
 }
 
-export function PageLoader({ error, onRetry, size = 280 }: PageLoaderProps) {
+export function PageLoader({ error, onRetry, size = 'lg' }: PageLoaderProps) {
   console.log('[PageLoader] Rendering with error:', error);
 
   return (
     <View style={styles.container}>
       <View style={styles.content}>
-        <AsciiSpinner size={size} color={colors.accent} resolution="medium" />
+        <View style={styles.spinnerContainer}>
+          <ThinkingSpinner size={size} variant="assemble" color={colors.accent} />
+        </View>
         {error ? (
           <View style={styles.errorContainer}>
             <Text style={styles.errorTitle}>UNABLE TO LOAD SESSION</Text>
@@ -46,6 +48,11 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     padding: spacing['3xl'],
+  },
+  spinnerContainer: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    transform: [{ scale: 1.3 }],
   },
   errorContainer: {
     alignItems: 'center',

--- a/packages/ui/src/components/PageLoader.tsx
+++ b/packages/ui/src/components/PageLoader.tsx
@@ -1,16 +1,18 @@
-import { AsciiSpinner } from '@vuhlp/spinners';
+import { ThinkingSpinner } from '@vuhlp/spinners';
 
 interface PageLoaderProps {
   error?: string | null;
   onRetry?: () => void;
-  size?: number;
+  size?: 'sm' | 'lg';
 }
 
-export function PageLoader({ error, onRetry, size = 300 }: PageLoaderProps) {
+export function PageLoader({ error, onRetry, size = 'lg' }: PageLoaderProps) {
   return (
     <div className="app__loader">
       <div className="app__loader-content">
-        <AsciiSpinner size={size} cycle />
+        <div className="app__loader-spinner" aria-hidden="true">
+          <ThinkingSpinner size={size} variant="assemble" color="var(--color-text-accent)" />
+        </div>
         {error ? (
           <div className="app__loader-error" role="alert">
             <div className="app__loader-title">Unable to load session</div>

--- a/packages/ui/src/styles/app.css
+++ b/packages/ui/src/styles/app.css
@@ -133,6 +133,14 @@
   text-align: center;
 }
 
+.app__loader-spinner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transform: scale(1.4);
+  transform-origin: center;
+}
+
 .app__loader-error {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
### Motivation
- Standardize on the chat `ThinkingSpinner` for all full-page and inline loading UIs instead of the 3D ASCII spinner for visual consistency.
- Ensure the spinner is appropriately sized when used for full-page loading so it remains visible on mobile and web.

### Description
- Replaced `AsciiSpinner` with `ThinkingSpinner` in `packages/ui/src/components/PageLoader.tsx` and `packages/mobile/src/components/PageLoader.tsx` and adjusted the default `size` prop to `'lg'` (type changed from `number` to `'sm' | 'lg'`).
- Wrapped the spinner in a container and applied scaling so the full-page loader appears larger on web via `.app__loader-spinner` in `packages/ui/src/styles/app.css`.
- Added a `spinnerContainer` style with a scale transform for the mobile loader in `packages/mobile/src/components/PageLoader.tsx` so the spinner is more prominent on mobile.
- Passed `variant="assemble"` and appropriate color values to `ThinkingSpinner` for consistent appearance with the chat UI.

### Testing
- Attempted to start the UI dev server with `pnpm --filter @vuhlp/ui dev -- --host 0.0.0.0 --port 4173`, but it failed due to missing `vite`/`node_modules` (dev server could not be started).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973b15a814c8325a053c305bcf14ee4)